### PR TITLE
Add @web-types/lit

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ At Lit's core is a boilerplate-killing component base class that provides reacti
 - [vscode-lit-plugin](https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin) - Syntax highlighting, type checking and code completion for lit-html.
 - [es6-string-html](https://marketplace.visualstudio.com/items?itemName=Tobermory.es6-string-html) - VSCode extension which provides syntax highlighting for HTML in ES6 multiline strings.
 - [vim-html-template-literals](https://github.com/jonsmithers/vim-html-template-literals) - Syntax highlighting and indentation for HTML inside of tagged template literals.
+- [@web-types/lit](https://www.npmjs.com/package/@web-types/lit) - Attribute completion for HTML inside of tagged template literals
 
 ### TypeScript Plugins
 


### PR DESCRIPTION
More info https://github.com/JetBrains/web-types#readme

As a reference, here's example of what (among others) it does:

Without:
<img width="694" alt="Screenshot 2022-10-22 at 12 27 03" src="https://user-images.githubusercontent.com/948356/197334288-03c5fe75-a9e6-4f74-afa1-22f8c7604912.png">
<img width="697" alt="Screenshot 2022-10-22 at 12 27 10" src="https://user-images.githubusercontent.com/948356/197334296-7a259b5d-78e0-4568-812b-0dd6ec07d4a8.png">

With:
<img width="696" alt="Screenshot 2022-10-22 at 12 26 33" src="https://user-images.githubusercontent.com/948356/197334303-0265f735-0c46-4c69-91aa-c6df5502ce9c.png">
